### PR TITLE
Update Makefile to support separate running of test types.

### DIFF
--- a/prog_question_test/Makefile
+++ b/prog_question_test/Makefile
@@ -1,10 +1,16 @@
 prepare:
 
-compile:
-
-test:	tests/autograde.py submission/template.py tests/prepend.py tests/append.py
+compile:	tests/autograde.py submission/template.py tests/prepend.py tests/append.py
 	cat tests/prepend.py submission/template.py tests/append.py tests/autograde.py > answer.py
-	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" python3 answer.py
+
+public:
+	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" python3 answer.py ProgQuestionPublic
+
+private:
+	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" python3 answer.py ProgQuestionPrivate
+
+evaluation:
+	PYTHONPATH="$(shell pwd)/submission":"$(shell pwd)/tests" python3 answer.py ProgQuestionEvaluation
 
 clean:
 	-rm answer.py


### PR DESCRIPTION
Shell script to invoke test framework has been modified to call the 3
targets public, private and evaluation. See https://github.com/Coursemology/evaluator-images/pull/18

Do not merge until the main app can parse multiple report files. References https://github.com/Coursemology/coursemology2/issues/2586